### PR TITLE
Upgrade the dbus package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "async": "~0.2.9",
-    "dbus": "^0.2.12",
+    "dbus": "^0.2.17",
     "debug": "^2.1.1"
   },
   "main": "./lib/connman"


### PR DESCRIPTION
The older package doesn't compile under newer node.js binaries.  This update compiles successfully under node,js 4.3.2 & 5.7.1 from resin
